### PR TITLE
Setting currency code to USD

### DIFF
--- a/lil wallet/Data/Data.swift
+++ b/lil wallet/Data/Data.swift
@@ -32,6 +32,7 @@ class Wallet: ObservableObject {
     func formatCurrency(value: NSNumber) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
+        formatter.currencyCode = "USD"
 
         let total = Double(truncating: value)
 


### PR DESCRIPTION
lil wallet shows the currency symbol of the current locale. This is wrong since it gets the data in USD. So, I think it is better to set `NumberFormatter.currencyCode` to USD.